### PR TITLE
Implémente le duty cycle

### DIFF
--- a/VERSION_8/README.md
+++ b/VERSION_8/README.md
@@ -33,3 +33,10 @@ python run.py --nodes 20 --mode Random --interval 15
 python run.py --nodes 5 --mode Periodic --interval 10
 
 panel serve dashboard.py --show
+
+## Duty cycle
+
+Un gestionnaire de duty cycle simple est disponible via `duty_cycle.py`. Vous
+pouvez l'activer dans `Simulator` en passant le paramètre `duty_cycle` (par
+exemple `0.01` pour 1 %). Les transmissions seront automatiquement retardées
+afin de respecter cette contrainte.

--- a/VERSION_8/launcher/__init__.py
+++ b/VERSION_8/launcher/__init__.py
@@ -4,3 +4,4 @@ from .gateway import Gateway
 from .channel import Channel
 from .server import NetworkServer
 from .simulator import Simulator
+from .duty_cycle import DutyCycleManager

--- a/VERSION_8/launcher/duty_cycle.py
+++ b/VERSION_8/launcher/duty_cycle.py
@@ -1,0 +1,24 @@
+class DutyCycleManager:
+    """Simple per-node duty cycle manager."""
+    def __init__(self, duty_cycle: float = 0.01):
+        if duty_cycle <= 0 or duty_cycle > 1:
+            raise ValueError("duty_cycle must be in (0,1]")
+        self.duty_cycle = duty_cycle
+        # next allowed transmission time per node id
+        self.next_tx_time = {}
+
+    def can_transmit(self, node_id: int, time: float) -> bool:
+        """Return True if node can transmit at given time."""
+        return time >= self.next_tx_time.get(node_id, 0.0)
+
+    def update_after_tx(self, node_id: int, start_time: float, duration: float):
+        """Update duty cycle info after a transmission."""
+        wait_time = duration * (1.0 / self.duty_cycle - 1.0)
+        next_time = start_time + duration + wait_time
+        cur = self.next_tx_time.get(node_id, 0.0)
+        if next_time > cur:
+            self.next_tx_time[node_id] = next_time
+
+    def enforce(self, node_id: int, requested_time: float) -> float:
+        """Return the earliest time the node can transmit given the duty cycle."""
+        return max(requested_time, self.next_tx_time.get(node_id, 0.0))

--- a/VERSION_8/launcher/simulator.py
+++ b/VERSION_8/launcher/simulator.py
@@ -7,6 +7,7 @@ from node import Node
 from gateway import Gateway
 from channel import Channel
 from server import NetworkServer
+from duty_cycle import DutyCycleManager
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,8 @@ class Simulator:
     
     def __init__(self, num_nodes: int = 10, num_gateways: int = 1, area_size: float = 1000.0,
                  transmission_mode: str = 'Random', packet_interval: float = 60.0,
-                 packets_to_send: int = 0, adr_node: bool = False, adr_server: bool = False):
+                 packets_to_send: int = 0, adr_node: bool = False, adr_server: bool = False,
+                 duty_cycle: float | None = None):
         """
         Initialise la simulation LoRa avec les entités et paramètres donnés.
         :param num_nodes: Nombre de nœuds à simuler.
@@ -30,6 +32,8 @@ class Simulator:
         :param packets_to_send: Nombre total de paquets à émettre avant d'arrêter la simulation (0 = infini).
         :param adr_node: Activation de l'ADR côté nœud.
         :param adr_server: Activation de l'ADR côté serveur.
+        :param duty_cycle: Facteur de duty cycle (ex: 0.01 pour 1 %). Si None,
+            le duty cycle est désactivé.
         """
         # Paramètres de simulation
         self.num_nodes = num_nodes
@@ -40,6 +44,9 @@ class Simulator:
         self.packets_to_send = packets_to_send
         self.adr_node = adr_node
         self.adr_server = adr_server
+
+        # Gestion du duty cycle
+        self.duty_cycle_manager = DutyCycleManager(duty_cycle) if duty_cycle else None
         
         # Initialiser le canal radio et le serveur réseau
         self.channel = Channel()
@@ -114,6 +121,8 @@ class Simulator:
         """Planifie un événement de transmission pour un nœud à l'instant donné."""
         event_id = self.event_id_counter
         self.event_id_counter += 1
+        if self.duty_cycle_manager:
+            time = self.duty_cycle_manager.enforce(node.id, time)
         heapq.heappush(self.event_queue, (time, 1, event_id, node))
         logger.debug(f"Scheduled transmission {event_id} for node {node.id} at t={time:.2f}s")
     
@@ -141,6 +150,8 @@ class Simulator:
             # Durée de la transmission
             duration = self.channel.airtime(sf)
             end_time = time + duration
+            if self.duty_cycle_manager:
+                self.duty_cycle_manager.update_after_tx(node_id, time, duration)
             # Mettre à jour le compteur de paquets émis
             self.packets_sent += 1
             # Énergie consommée par la transmission (E = P(mW) * t)


### PR DESCRIPTION
## Notes
- Les tests échouent car `numpy` et `panel` ne sont pas installés dans l'environnement

## Summary
- ajout d’un gestionnaire `DutyCycleManager`
- activation optionnelle du duty cycle dans `Simulator`
- mise à jour de `__init__` et du README

------
https://chatgpt.com/codex/tasks/task_e_6850738dbbd483318aa5cd9af1280c67