### PR TITLE
Fix relative imports

### DIFF
--- a/VERSION_8/launcher/simulator.py
+++ b/VERSION_8/launcher/simulator.py
@@ -3,11 +3,12 @@ import heapq
 import numpy as np
 import pandas as pd
 import logging
-from node import Node
-from gateway import Gateway
-from channel import Channel
-from server import NetworkServer
-from duty_cycle import DutyCycleManager
+
+from .node import Node
+from .gateway import Gateway
+from .channel import Channel
+from .server import NetworkServer
+from .duty_cycle import DutyCycleManager
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- fix imports in Simulator to use package-relative paths

## Testing
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6850948376ac833187c5a30d49a386c8