### PR TITLE
Fix Panel import path

### DIFF
--- a/VERSION_8/launcher/dashboard.py
+++ b/VERSION_8/launcher/dashboard.py
@@ -1,7 +1,10 @@
 import panel as pn
 import pandas as pd
 import plotly.graph_objects as go
-from simulator import Simulator
+# Import du simulateur depuis le paquet `launcher`
+# afin que les imports relatifs internes fonctionnent lorsque
+# ce script est servi avec Panel depuis la racine du projet.
+from launcher.simulator import Simulator
 import numpy as np
 import time
 import os


### PR DESCRIPTION
## Summary
- import `Simulator` from the `launcher` package in the Panel dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy and panel)*

------
https://chatgpt.com/codex/tasks/task_e_68509b619fc88331add684913eb38336