### PR TITLE
Fix Panel title attribute

### DIFF
--- a/VERSION_8/launcher/dashboard.py
+++ b/VERSION_8/launcher/dashboard.py
@@ -11,7 +11,8 @@ import os
 
 # --- Initialisation Panel ---
 pn.extension('plotly')
-pn.config.title = "Simulateur LoRa"
+# Définition du titre de la page via le document Bokeh directement
+pn.state.curdoc.title = "Simulateur LoRa"
 
 # --- Variables globales ---
 sim = None


### PR DESCRIPTION
## Summary
- fix Panel dashboard initialization by setting the page title via `pn.state.curdoc`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6850a187127083318c4716a69688d048